### PR TITLE
adding path override functionality

### DIFF
--- a/cli/generate/generate.go
+++ b/cli/generate/generate.go
@@ -78,7 +78,7 @@ func NewGenerateCmd(ctx Ctx) *cobra.Command {
 				}
 			}
 
-			if err := gen.Generate(parameterValues); err != nil {
+			if err := gen.Generate(parameterValues, &templateProps.Overrides); err != nil {
 				log.WithError(err).Fatal("error processing template")
 			}
 		},

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/thmhoag/codectl
 go 1.12
 
 require (
-	github.com/AlecAivazis/survey/v2 v2.0.4
+	github.com/AlecAivazis/survey/v2 v2.1.1
 	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/Masterminds/sprig v2.18.0+incompatible
 	github.com/antonfisher/nested-logrus-formatter v1.0.2
@@ -15,6 +15,7 @@ require (
 	github.com/imdario/mergo v0.3.8 // indirect
 	github.com/manifoldco/promptui v0.3.2
 	github.com/mitchellh/go-homedir v1.1.0
+	github.com/nicksnyder/go-i18n v1.10.1 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/rhysd/go-github-selfupdate v1.1.0
 	github.com/sirupsen/logrus v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ dmitri.shuralyov.com/state v0.0.0-20180228185332-28bcc343414c/go.mod h1:0PRwlb0D
 git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
 github.com/AlecAivazis/survey/v2 v2.0.4 h1:qzXnJSzXEvmUllWqMBWpZndvT2YfoAUzAMvZUax3L2M=
 github.com/AlecAivazis/survey/v2 v2.0.4/go.mod h1:WYBhg6f0y/fNYUuesWQc0PKbJcEliGcYHB9sNT3Bg74=
+github.com/AlecAivazis/survey/v2 v2.1.1 h1:LEMbHE0pLj75faaVEKClEX1TM4AJmmnOh9eimREzLWI=
+github.com/AlecAivazis/survey/v2 v2.1.1/go.mod h1:9FJRdMdDm8rnT+zHVbvQT2RTSTLq0Ttd6q3Vl2fahjk=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
@@ -231,6 +233,8 @@ github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/neelance/astrewrite v0.0.0-20160511093645-99348263ae86/go.mod h1:kHJEU3ofeGjhHklVoIGuVj85JJwZ6kWPaJwCIxgnFmo=
 github.com/neelance/sourcemap v0.0.0-20151028013722-8c68805598ab/go.mod h1:Qr6/a/Q4r9LP1IltGz7tA7iOK1WonHEYhu1HRBA7ZiM=
+github.com/nicksnyder/go-i18n v1.10.1 h1:isfg77E/aCD7+0lD/D00ebR2MV5vgeQ276WYyDaCRQc=
+github.com/nicksnyder/go-i18n v1.10.1/go.mod h1:e4Di5xjP9oTVrC6y3C7C0HoSYXjSbhh/dU0eUV32nB4=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/onsi/ginkgo v1.6.0 h1:Ix8l273rp3QzYgXSR+c8d1fTG7UPgYkOSELPhiY/YGw=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"text/template"
 
@@ -217,10 +216,6 @@ func processPath(g *generator, fileName string, parmsObject interface{}, overrid
 	}
 
 	newFileName = buf.String()
-
-	if runtime.GOOS == "windows" {
-		newFileName = strings.ReplaceAll(newFileName, "/", `\`)
-	}
 
 	return newFileName, nil
 }

--- a/pkg/template/list.go
+++ b/pkg/template/list.go
@@ -8,6 +8,7 @@ import (
 	"gopkg.in/yaml.v2"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 )
 
@@ -41,6 +42,10 @@ func GetAll(box *packr.Box, dir string) (map[string]*Properties, error) {
 		if props.Name == "" {
 			props.Name = strings.ReplaceAll(filepath.Dir(fileInfo.Name()), "/", ".")
 			props.Name = strings.ReplaceAll(props.Name, `\`, ".")
+		}
+
+		if props.Overrides.Paths != nil {
+			props.Overrides.Paths = prepOverridePaths(props.Overrides.Paths)
 		}
 
 		templates[props.Name] = props
@@ -77,4 +82,24 @@ func unmarshalProperties(file packd.File) (*Properties, error) {
 	}
 
 	return props, nil
+}
+
+func prepOverridePaths(overrides map[string]string) map[string]string {
+	newPaths := make(map[string]string)
+
+	for k, v := range overrides {
+		newKey := k
+
+		if !strings.HasPrefix(newKey, "/") {
+			newKey = "/" + newKey
+		}
+
+		if runtime.GOOS == "windows" {
+			newKey = strings.ReplaceAll(newKey, "/", `\`)
+		}
+
+		newPaths[newKey] = v
+	}
+
+	return newPaths
 }

--- a/pkg/template/overrides.go
+++ b/pkg/template/overrides.go
@@ -1,0 +1,7 @@
+package template
+
+// Overrides defines replacement text for names of items in the templates
+type Overrides struct {
+	//Paths contains the file/folder names and the override values
+	Paths map[string]string `yaml:"paths"`
+}

--- a/pkg/template/properties.go
+++ b/pkg/template/properties.go
@@ -17,4 +17,8 @@ type Properties struct {
 	// Dependencies is a list of the paths of the dependent templates that will be
 	// called with this one
 	Dependencies []string `yaml:"dependencies"`
+
+	// Overrides contains a list of paths that will have their names
+	// changed to the values in the override before template processing occurs
+	Overrides Overrides `yaml:"overrides"`
 }


### PR DESCRIPTION
Adding ability to override template file paths with other values.  The replacement values can be either literal text or template syntax.

Example:
If the .codectl.yaml file contains:
```
version: 0.0.1
description: a template for helm charts
parameters:
- name: FirstName
  prompt: "First name"
  required: true
- name: LastName
  prompt: "Last name"
  required: true
overrides:
  paths:
    ".operations/chart": '.operations/{{ (print .FirstName "--" .LastName) | lower}}'
```
Assuming the values: FirstName=foo, LastName=bar, then any files in the `.operations/chart` folder in the template would be placed in the `.operations/foo--bar` folder in the generated output.